### PR TITLE
Add .gitignore for downloads directory and release artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Downloaded release files (created by CI workflow)
+downloads/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor files
+*.swp
+*.swo
+*~
+.vscode/
+.idea/
+
+# Tor Browser installers (should never be committed to the repo)
+*.exe
+*.dmg
+*.tar.xz
+*.apk
+*.ipa


### PR DESCRIPTION
## Summary

Adds a `.gitignore` file to prevent accidentally committing large binary files and common artifacts to the repository.

### What it ignores

- **`downloads/`** — The CI workflow (`mirror-tor-browser.yml`) creates this directory to store downloaded Tor Browser installers before uploading them as GitHub release assets. These files should never be committed to the repo (they are large binaries, some 80MB+).
- **Release artifacts** — `.exe`, `.dmg`, `.tar.xz`, `.apk`, `.ipa` files that the mirror workflow handles should never end up in the git tree.
- **Common OS/editor files** — `.DS_Store`, `Thumbs.db`, editor swap files, `.vscode/`, `.idea/`

### Why this matters

Without a `.gitignore`, anyone working on this repo locally (e.g., running the mirror script for testing) could accidentally stage and commit the downloaded browser installers, which are:

- Very large (hundreds of MB total)
- Regenerated by the CI on every run
- Already distributed via GitHub Releases

## Testing

- Verified the `.gitignore` correctly excludes the `downloads/` directory and binary file types
- No changes to existing functionality
